### PR TITLE
Replaces 1s with bullet points

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Patient
 =======
 ###Contributing
 
-1. Create a new feature branch
+* Create a new feature branch
 ```
 git checkout -b branchname
 ```
@@ -10,7 +10,7 @@ or switch to an existing branch with
 ```
 git checkout branchname
 ```
-2. After making changes, save your changes to your local
+* After making changes, save your changes to your local
 file system, and add them to the staging area. If you created
 a file in Patient/Scenes called AwesomeScene.goat
 ```
@@ -21,24 +21,24 @@ or to add every change, use
 git add .
 ```
 
-3. now commit the new change with a useful message
+* now commit the new change with a useful message
 ```
 git commit -m "Adds a new scene called AwesomeScene"
 ```
 
-4. go back to your master branch with
+* go back to your master branch with
 ```
 git checkout master
 ```
 
-5. Merge your changes to your master branch
+* Merge your changes to your master branch
 ```
 git merge branchname
 ```
 
-6. push your changes to your forked repository
+* push your changes to your forked repository
 ```
 git push
 ```
 
-7. Submit a pull request.
+* Submit a pull request.


### PR DESCRIPTION
Replaces all of the 1s in the README with bullet points, the raw file is numbered but the markdown renders as all 1s. So I replaced them with bullets because I don't want to mess with markdown
